### PR TITLE
async_stream indexes and use :prim_file on hot code paths

### DIFF
--- a/scripts/vet_files.exs
+++ b/scripts/vet_files.exs
@@ -7,13 +7,13 @@ index_file = "tmp/files/index.txt"
 
 index_file
 |> File.stream!()
-|> Stream.each(fn line ->
+|> Task.async_stream(fn line ->
   path = String.trim(line)
-  {:ok, contents} = File.read(path)
+  {:ok, contents} = :prim_file.read_file(path)
   {:ok, %{"paths" => txt_paths}} = Jason.decode(contents)
 
   Enum.each(txt_paths, fn p ->
-    File.exists?(p)
+    :prim_file.read_file_info(p)
   end)
 end)
 |> Stream.run()


### PR DESCRIPTION
A few improvements that gets the elixir duration closer to python on my system

```
➜  ex_vs_py git:(async-prim-file) ✗ python scripts/vet_files.py
Duration: 308 ms
➜  ex_vs_py git:(async-prim-file) ✗ mix run scripts/vet_files.exs
Duration: 400 ms
```